### PR TITLE
Updates for sanger staging website

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# build environment
+FROM node as builder
+RUN apt-get install git
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+ENV PATH /usr/src/app/node_modules/.bin:$PATH
+COPY package.json /usr/src/app/package.json
+RUN yarn install
+RUN npm install react-scripts@1.1.4 -g --silent
+COPY . /usr/src/app
+RUN npm run build
+
+# production environment
+FROM nginx:1.15-alpine
+COPY --from=builder /usr/src/app/build /usr/share/nginx/html
+RUN rm -rf /etc/nginx/conf.d
+COPY conf /etc/nginx
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/conf/conf.d/default.conf
+++ b/conf/conf.d/default.conf
@@ -1,0 +1,12 @@
+server {
+  listen 80;
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html;
+  }
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+    root   /usr/share/nginx/html;
+  }
+}

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -1,0 +1,21 @@
+version: '3.5'
+
+services:
+
+  frontend:
+    image: registry.production.team215.sanger.ac.uk/score_frontend:staging
+    networks:
+      - traefik_net
+    deploy:
+      replicas: 2
+      labels:
+        - "traefik.api.port=80"
+        - "traefik.docker.network=traefik_net"
+        - "traefik.api.frontend.rule=Host:score.staging.team215.sanger.ac.uk"
+        - "traefik.frontend.entryPoints=http"
+
+networks:
+  traefik_net:
+    external: true
+
+    

--- a/src/containers/genePage/index.js
+++ b/src/containers/genePage/index.js
@@ -1,6 +1,6 @@
 import identity from 'lodash.identity';
 import pickBy from 'lodash.pickby';
-import queryString from 'query-string';
+import queryString from 'qs';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';

--- a/src/containers/modelPage/index.js
+++ b/src/containers/modelPage/index.js
@@ -1,6 +1,6 @@
 import identity from 'lodash.identity';
 import pickBy from 'lodash.pickby';
-import queryString from 'query-string';
+import queryString from 'qs';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';

--- a/src/containers/table/index.js
+++ b/src/containers/table/index.js
@@ -8,7 +8,7 @@ import $ from 'jquery';
 import axios from 'axios';
 import cols from './columns';
 import { history } from '../../store/store';
-import queryString from 'query-string';
+import queryString from 'qs';
 import FilterBox from '../filterBox';
 import TissuesChips from '../tissueChip';
 import ValuesFilter from '../valuesFilter';

--- a/src/containers/tablePage/index.js
+++ b/src/containers/tablePage/index.js
@@ -4,7 +4,7 @@ import CustomTable from '../customTable';
 import Filters from '../filters';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import queryString from 'query-string';
+import queryString from 'qs';
 import pickBy from 'lodash.pickby';
 import identity from 'lodash.identity';
 import { tableTissueFilter } from '../../modules/actions/table';

--- a/src/modules/actions/modelEssentialities.js
+++ b/src/modules/actions/modelEssentialities.js
@@ -33,8 +33,9 @@ export function fetchModelEssentialities(model) {
       return axios
         .get(`${API_BASEURL}/models/${model}/datasets/crispr`, {
           params: {
-            filter: JSON.stringify(filters),
-            'page[size]': 0
+            'page[size]': 0,
+            'fields[crispr_data]':
+              'bagel_bf_scaled,fc_corrected,gene_symbol,model_name'
           }
         })
         .then(modelEssentialities => {


### PR DESCRIPTION
Hi Miguel,

here are the updates I've had to do to get the website running at Sanger.

1. Added dockerfiles and NGINX configuration for Sanger internal deployment
2. Updated query-string to qs to allow production builds
3. Updated fetchModelEssentialities to speed up response and prevent occasional timeouts

I'm happy to leave this as a separate branch, but I thought you might want to merge them into master.
